### PR TITLE
fix: check if file exists before delete

### DIFF
--- a/SSDProject/SSD_TC/SSD_TC.vcxproj
+++ b/SSDProject/SSD_TC/SSD_TC.vcxproj
@@ -58,6 +58,7 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/SSDProject/SSD_TC/test.cpp
+++ b/SSDProject/SSD_TC/test.cpp
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <vector>
 #include <string>
+#include <filesystem>
 
 using namespace std;
 using namespace testing;
@@ -46,8 +47,10 @@ public:
 	}
 	void TearDown()
 	{
-		system(("del " + NAND_FILE).c_str());
-		system(("del " + RESULT_FILE).c_str());
+		if (std::filesystem::exists(NAND_FILE))
+			system(("del " + NAND_FILE).c_str());
+		if (std::filesystem::exists(RESULT_FILE))
+			system(("del " + RESULT_FILE).c_str());
 	}
 	string getData(string fileName, int targetLine)
 	{


### PR DESCRIPTION
SSDFixture의 TearDown()에서 file을 지우기 전에 exist를 확인했습니다.
std::filesystem이 cpp17에서 추가되었기 때문에 VS의 기본 설정(cpp14)을 cpp17로 변경했습니다.